### PR TITLE
Fix ripple cluster shader buffer bounds

### DIFF
--- a/DropletRippleTest/RippleField.swift
+++ b/DropletRippleTest/RippleField.swift
@@ -224,7 +224,8 @@ struct MultiRippleModifier: ViewModifier {
                         .float(Float(parameters.wavelength)),        // wavelength
                         .float(Float(parameters.speed)),             // speed
                         .float(Float(parameters.ringWidth)),         // ringWidth
-                        .floatArray(packed)                          // rippleData (pointer + length provided by stitching)
+                        .floatArray(packed),                         // rippleData (pointer + length provided by stitching)
+                        .int(Int32(packed.count))                    // rippleFloatCount (number of floats)
                     ),
                     maxSampleOffset: CGSize(width: maxSample, height: maxSample),
                     isEnabled: isEnabled


### PR DESCRIPTION
## Summary
- clamp the ripple cluster shader to the number of floats provided to avoid stale data reads
- pass the packed buffer length from Swift so Metal can stop before running out of entries

## Testing
- Not run (not available on linux)


------
https://chatgpt.com/codex/tasks/task_e_68e29e3e0b70832897b8f7c02a0a404d