### PR TITLE
Add ripple style picker with prismatic and bloom effects

### DIFF
--- a/DropletRippleTest/ContentView.swift
+++ b/DropletRippleTest/ContentView.swift
@@ -8,20 +8,137 @@
 import SwiftUI
 import QuartzCore
 
+enum RippleVisualPreset: String, CaseIterable, Identifiable {
+    case classic
+    case prismatic
+    case aquaBloom
+
+    var id: String { rawValue }
+}
+
+struct RippleStyleDefinition: Identifiable {
+    let id: RippleVisualPreset
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    let accent: Color
+}
+
+struct RippleStyleEntry {
+    let definition: RippleStyleDefinition
+    let defaultState: StyleRuntimeState
+}
+
+struct StyleRuntimeState {
+    var parameters: RippleParameters
+    var prism: RipplePrismConfiguration?
+    var glow: RippleGlowConfiguration?
+
+    var style: RippleFieldStyle {
+        if let prism { return .prismatic(prism) }
+        if let glow { return .luminous(glow) }
+        return .distortionOnly
+    }
+}
+
+extension RippleVisualPreset {
+    static let catalog: [RippleVisualPreset: RippleStyleEntry] = {
+        let baseParameters = RippleParameters(
+            amplitude: 12,
+            wavelength: 140,
+            speed: 2.2,
+            decay: 1.6,
+            ringWidth: 36,
+            minimumAmplitude: 0.15,
+            maximumSampleOffset: 72
+        )
+
+        return [
+            .classic: RippleStyleEntry(
+                definition: RippleStyleDefinition(
+                    id: .classic,
+                    title: "Classic",
+                    subtitle: "Original multi-ripple distortion",
+                    systemImage: "dot.viewfinder",
+                    accent: Color.cyan
+                ),
+                defaultState: StyleRuntimeState(parameters: baseParameters,
+                                                 prism: nil,
+                                                 glow: nil)
+            ),
+            .prismatic: RippleStyleEntry(
+                definition: RippleStyleDefinition(
+                    id: .prismatic,
+                    title: "Prismatic",
+                    subtitle: "Chromatic refraction with subtle tint",
+                    systemImage: "camera.macro",
+                    accent: Color.purple
+                ),
+                defaultState: StyleRuntimeState(
+                    parameters: RippleParameters(
+                        amplitude: 13.5,
+                        wavelength: 150,
+                        speed: 2.15,
+                        decay: 1.5,
+                        ringWidth: 40,
+                        minimumAmplitude: baseParameters.minimumAmplitude,
+                        maximumSampleOffset: 120
+                    ),
+                    prism: RipplePrismConfiguration(
+                        refractionStrength: 0.65,
+                        dispersion: 0.45,
+                        tintStrength: 0.38,
+                        tintColor: Color(red: 0.55, green: 0.85, blue: 1.0)
+                    ),
+                    glow: nil
+                )
+            ),
+            .aquaBloom: RippleStyleEntry(
+                definition: RippleStyleDefinition(
+                    id: .aquaBloom,
+                    title: "Aqua Bloom",
+                    subtitle: "Soft luminous bloom that follows the ripples",
+                    systemImage: "sparkles",
+                    accent: Color.blue
+                ),
+                defaultState: StyleRuntimeState(
+                    parameters: RippleParameters(
+                        amplitude: 15,
+                        wavelength: 160,
+                        speed: 2.0,
+                        decay: 1.4,
+                        ringWidth: 44,
+                        minimumAmplitude: baseParameters.minimumAmplitude,
+                        maximumSampleOffset: 140
+                    ),
+                    prism: nil,
+                    glow: RippleGlowConfiguration(
+                        glowStrength: 0.9,
+                        highlightPower: 1.6,
+                        highlightBoost: 1.2,
+                        glowColor: Color(red: 0.45, green: 0.8, blue: 1.0)
+                    )
+                )
+            )
+        ]
+    }()
+
+    static var defaultStates: [RippleVisualPreset: StyleRuntimeState] {
+        var map: [RippleVisualPreset: StyleRuntimeState] = [:]
+        for (key, entry) in catalog {
+            map[key] = entry.defaultState
+        }
+        return map
+    }
+}
+
 /// A simple "home screen" with tappable icons. Tapping triggers a full-screen ripple.
 struct ContentView: View {
     @State private var rippleEngine = RippleEngine()
     @State private var isMulti: Bool = true
-
-    private let rippleParameters = RippleParameters(
-        amplitude: 12,
-        wavelength: 140,
-        speed: 2.2,
-        decay: 1.6,
-        ringWidth: 36,
-        minimumAmplitude: 0.15,
-        maximumSampleOffset: 72
-    )
+    @State private var selectedStyle: RippleVisualPreset = .classic
+    @State private var styleStates: [RippleVisualPreset: StyleRuntimeState] = RippleVisualPreset.defaultStates
+    @State private var showStyleStudio: Bool = false
 
     private let rippleSpaceName = "ripple-field-space"
 
@@ -36,7 +153,10 @@ struct ContentView: View {
     }
 
     var body: some View {
-        ZStack {
+        let entry = RippleVisualPreset.catalog[selectedStyle] ?? RippleVisualPreset.catalog[.classic]!
+        let currentState = styleStates[selectedStyle] ?? entry.defaultState
+
+        return ZStack {
 
             // Interactive grid (fully visible and receives gestures)
             HomeGrid(
@@ -44,7 +164,6 @@ struct ContentView: View {
                 coordinateSpace: .named(rippleSpaceName)
             ) { iconCenter in
                 rippleEngine.emit(at: iconCenter)
-                print("fired")
             }
             .opacity(0.1)
 
@@ -67,37 +186,95 @@ struct ContentView: View {
 
             }
             .allowsHitTesting(false)
-            .rippleField(engine: rippleEngine, parameters: rippleParameters, mode: isMulti ? .multi : .single)
+            .rippleField(engine: rippleEngine,
+                         parameters: currentState.parameters,
+                         eventSpace: .named(rippleSpaceName),
+                         mode: isMulti ? .multi : .single,
+                         style: currentState.style)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(.systemBackground))
         .coordinateSpace(name: rippleSpaceName)
         .contentShape(Rectangle())
         .safeAreaInset(edge: .bottom) {
-            HStack(spacing: 12) {
-                Text("Ripple mode")
-                    .font(.footnote)
-                Toggle(isOn: $isMulti) {
-                    Text(isMulti ? "Multi" : "Single")
-                        .font(.footnote)
+            VStack(spacing: 12) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        ForEach(RippleVisualPreset.allCases) { preset in
+                            if let entry = RippleVisualPreset.catalog[preset] {
+                                let definition = entry.definition
+                                let isSelected = preset == selectedStyle
+
+                                Button {
+                                    selectedStyle = preset
+                                } label: {
+                                    HStack(spacing: 8) {
+                                        Image(systemName: definition.systemImage)
+                                            .font(.system(size: 14, weight: .semibold))
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(definition.title)
+                                                .font(.footnote)
+                                                .fontWeight(.semibold)
+                                            Text(definition.subtitle)
+                                                .font(.caption2)
+                                                .lineLimit(1)
+                                        }
+                                    }
+                                    .foregroundStyle(isSelected ? .white : .primary)
+                                    .padding(.horizontal, 14)
+                                    .padding(.vertical, 10)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                            .fill(isSelected ? definition.accent.opacity(0.85) : .ultraThinMaterial)
+                                    )
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 12)
                 }
-                .toggleStyle(.switch)
+
+                Button {
+                    showStyleStudio = true
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "slider.horizontal.3")
+                        Text("Open Ripple Studio")
+                    }
+                    .font(.footnote.weight(.semibold))
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .fill(.ultraThinMaterial)
+                    )
+                }
+                .buttonStyle(.plain)
             }
             .padding(.horizontal, 16)
-            .padding(.vertical, 10)
+            .padding(.vertical, 12)
             .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
                     .fill(.ultraThinMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.08))
+                    )
             )
             .padding(.horizontal, 16)
-            .padding(.bottom, 8)
+            .padding(.bottom, 12)
         }
-//        .gesture(
-//            DragGesture(minimumDistance: 0)
-//                .onChanged { value in
-//                    rippleEngine.emit(at: value.location)
-//                }
-//        )
+        .sheet(isPresented: $showStyleStudio) {
+            RippleStyleControlPanel(
+                selection: $selectedStyle,
+                styleStates: $styleStates,
+                catalog: RippleVisualPreset.catalog
+            )
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+        }
     }
 }
 
@@ -180,6 +357,245 @@ struct IconTile: View {
             tapped(centerInSpace)
         }
         .frame(height: 96) // grid cell height
+    }
+}
+
+struct RippleStyleControlPanel: View {
+    @Binding var selection: RippleVisualPreset
+    @Binding var styleStates: [RippleVisualPreset: StyleRuntimeState]
+    let catalog: [RippleVisualPreset: RippleStyleEntry]
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                stylePickerSection
+
+                if let binding = binding(for: selection),
+                   let entry = catalog[selection] {
+                    waveParameterSection(binding: binding)
+                    if entry.defaultState.prism != nil,
+                       let prismBinding = binding.prismBinding(default: entry.defaultState.prism) {
+                        prismSection(binding: prismBinding)
+                    }
+                    if entry.defaultState.glow != nil,
+                       let glowBinding = binding.glowBinding(default: entry.defaultState.glow) {
+                        glowSection(binding: glowBinding)
+                    }
+                }
+            }
+            .navigationTitle("Ripple Studio")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var stylePickerSection: some View {
+        Section("Style") {
+            Picker("Visual Style", selection: $selection) {
+                ForEach(RippleVisualPreset.allCases) { preset in
+                    if let definition = catalog[preset]?.definition {
+                        Text(definition.title).tag(preset)
+                    }
+                }
+            }
+            .pickerStyle(.segmented)
+
+            if let definition = catalog[selection]?.definition {
+                Text(definition.subtitle)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func waveParameterSection(binding: Binding<StyleRuntimeState>) -> some View {
+        Section {
+            ParameterSliderRow("Amplitude",
+                               value: binding.parameterBinding(\.parameters.amplitude),
+                               range: 6...26,
+                               step: 0.5,
+                               suffix: " pt")
+            ParameterSliderRow("Wavelength",
+                               value: binding.parameterBinding(\.parameters.wavelength),
+                               range: 100...220,
+                               step: 1,
+                               suffix: " pt")
+            ParameterSliderRow("Speed",
+                               value: binding.parameterBinding(\.parameters.speed),
+                               range: 0.8...3.0,
+                               step: 0.05,
+                               suffix: " ×")
+            ParameterSliderRow("Ring width",
+                               value: binding.parameterBinding(\.parameters.ringWidth),
+                               range: 20...72,
+                               step: 1,
+                               suffix: " pt")
+            ParameterSliderRow("Decay",
+                               value: binding.parameterBinding(\.parameters.decay),
+                               range: 0.8...2.6,
+                               step: 0.05,
+                               suffix: " ×")
+        } footer: {
+            Text("These settings mirror the classic multi-ripple behaviour. Adjust them to fine-tune the wave physics for any style.")
+        }
+    }
+
+    private func prismSection(binding: Binding<RipplePrismConfiguration>) -> some View {
+        Section("Prismatic Refraction") {
+            ParameterSliderRow("Refraction",
+                               value: binding.binding(for: \.refractionStrength),
+                               range: 0.2...1.4,
+                               step: 0.02)
+            ParameterSliderRow("Dispersion",
+                               value: binding.binding(for: \.dispersion),
+                               range: 0...1.2,
+                               step: 0.02)
+            ParameterSliderRow("Tint mix",
+                               value: binding.binding(for: \.tintStrength),
+                               range: 0...1,
+                               step: 0.02)
+            ColorPicker("Tint colour",
+                        selection: Binding(
+                            get: { binding.wrappedValue.tintColor },
+                            set: { binding.wrappedValue.tintColor = $0 }
+                        ))
+        } footer: {
+            Text("Refraction bends the background image, while dispersion separates colour channels for a glassy fringe.")
+        }
+    }
+
+    private func glowSection(binding: Binding<RippleGlowConfiguration>) -> some View {
+        Section("Luminous Bloom") {
+            ParameterSliderRow("Glow strength",
+                               value: binding.binding(for: \.glowStrength),
+                               range: 0...1.8,
+                               step: 0.02)
+            ParameterSliderRow("Highlight focus",
+                               value: binding.binding(for: \.highlightPower),
+                               range: 0.6...3.0,
+                               step: 0.05)
+            ParameterSliderRow("Halo lift",
+                               value: binding.binding(for: \.highlightBoost),
+                               range: 0...3.0,
+                               step: 0.05)
+            ColorPicker("Glow colour",
+                        selection: Binding(
+                            get: { binding.wrappedValue.glowColor },
+                            set: { binding.wrappedValue.glowColor = $0 }
+                        ))
+        } footer: {
+            Text("Tune the bloom that trails each crest. Increase glow strength for brighter waves or halo lift for a softer aura.")
+        }
+    }
+
+    private func binding(for preset: RippleVisualPreset) -> Binding<StyleRuntimeState>? {
+        guard let entry = catalog[preset] else { return nil }
+        return Binding(
+            get: { styleStates[preset] ?? entry.defaultState },
+            set: { styleStates[preset] = $0 }
+        )
+    }
+}
+
+private struct ParameterSliderRow: View {
+    let title: String
+    let value: Binding<CGFloat>
+    let range: ClosedRange<CGFloat>
+    let step: CGFloat
+    let suffix: String
+
+    init(_ title: String,
+         value: Binding<CGFloat>,
+         range: ClosedRange<CGFloat>,
+         step: CGFloat,
+         suffix: String = "") {
+        self.title = title
+        self.value = value
+        self.range = range
+        self.step = max(step, 0.001)
+        self.suffix = suffix
+    }
+
+    private var formattedValue: String {
+        let val = value.wrappedValue
+        if step >= 1 {
+            return String(format: "%.0f%@", val, suffix)
+        } else if step >= 0.1 {
+            return String(format: "%.1f%@", val, suffix)
+        } else {
+            return String(format: "%.2f%@", val, suffix)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                Spacer()
+                Text(formattedValue)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Slider(value: Binding(
+                get: { Double(value.wrappedValue) },
+                set: { value.wrappedValue = CGFloat($0) }
+            ), in: Double(range.lowerBound)...Double(range.upperBound), step: Double(step))
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private extension Binding where Value == StyleRuntimeState {
+    func parameterBinding(_ keyPath: WritableKeyPath<RippleParameters, CGFloat>) -> Binding<CGFloat> {
+        Binding<CGFloat>(
+            get: { self.wrappedValue.parameters[keyPath: keyPath] },
+            set: { self.wrappedValue.parameters[keyPath: keyPath] = $0 }
+        )
+    }
+
+    func prismBinding(default defaultValue: RipplePrismConfiguration?) -> Binding<RipplePrismConfiguration>? {
+        guard let defaultValue else { return nil }
+        return Binding<RipplePrismConfiguration>(
+            get: { self.wrappedValue.prism ?? defaultValue },
+            set: { newValue in
+                self.wrappedValue.prism = newValue
+                self.wrappedValue.glow = nil
+            }
+        )
+    }
+
+    func glowBinding(default defaultValue: RippleGlowConfiguration?) -> Binding<RippleGlowConfiguration>? {
+        guard let defaultValue else { return nil }
+        return Binding<RippleGlowConfiguration>(
+            get: { self.wrappedValue.glow ?? defaultValue },
+            set: { newValue in
+                self.wrappedValue.glow = newValue
+                self.wrappedValue.prism = nil
+            }
+        )
+    }
+}
+
+private extension Binding where Value == RipplePrismConfiguration {
+    func binding(for keyPath: WritableKeyPath<RipplePrismConfiguration, CGFloat>) -> Binding<CGFloat> {
+        Binding<CGFloat>(
+            get: { self.wrappedValue[keyPath: keyPath] },
+            set: { self.wrappedValue[keyPath: keyPath] = $0 }
+        )
+    }
+}
+
+private extension Binding where Value == RippleGlowConfiguration {
+    func binding(for keyPath: WritableKeyPath<RippleGlowConfiguration, CGFloat>) -> Binding<CGFloat> {
+        Binding<CGFloat>(
+            get: { self.wrappedValue[keyPath: keyPath] },
+            set: { self.wrappedValue[keyPath: keyPath] = $0 }
+        )
     }
 }
 

--- a/DropletRippleTest/ripple.metal
+++ b/DropletRippleTest/ripple.metal
@@ -180,3 +180,199 @@ float2 rippleCluster(float2 position,
 
     return position + totalOffset;
 }
+
+[[ stitchable ]]
+half4 rippleClusterPrismColor(float2 position,
+                              SwiftUI::Layer layer,
+                              float2 size,
+                              float  wavelength,
+                              float  speed,
+                              float  ringWidth,
+                              float  refractionStrength,
+                              float  dispersion,
+                              float  tintStrength,
+                              float3 tintColor,
+                              constant float *rippleData,
+                              int    rippleFloatCount)
+{
+    if (!isfinite(wavelength) || !isfinite(speed) || !isfinite(ringWidth) ||
+        !isfinite(refractionStrength) || !isfinite(dispersion) || !isfinite(tintStrength)) {
+        return layer.sample(position);
+    }
+
+    if (rippleData == nullptr || rippleFloatCount < 4) {
+        return layer.sample(position);
+    }
+
+    const float tau = 6.28318530718;
+    const float safeWavelength = max(wavelength, 1.0);
+    const float safeRing = max(ringWidth, 1.0);
+    const float safeRefraction = clamp(refractionStrength, 0.0, 3.0);
+    const float safeDispersion = clamp(dispersion, 0.0, 2.0);
+    const float safeTint = clamp(tintStrength, 0.0, 1.0);
+    const float falloffRadius = 0.5 * length(size);
+
+    int limitedFloatCount = clamp(rippleFloatCount, 0, 64 * 4);
+    int count = limitedFloatCount / 4;
+    if (count <= 0) {
+        return layer.sample(position);
+    }
+
+    float2 totalOffset = float2(0.0, 0.0);
+    float maxEnvelope = 0.0;
+    float totalMagnitude = 0.0;
+
+    for (int i = 0; i < count; ++i) {
+        int baseIndex = i * 4;
+        if ((baseIndex + 3) >= limitedFloatCount) {
+            break;
+        }
+
+        float cx  = rippleData[baseIndex + 0];
+        float cy  = rippleData[baseIndex + 1];
+        float age = rippleData[baseIndex + 2];
+        float amp = rippleData[baseIndex + 3];
+
+        if (!isfinite(cx) || !isfinite(cy) || !isfinite(age) || !isfinite(amp) || amp <= 0.0001) {
+            continue;
+        }
+
+        float2 center = float2(cx, cy);
+        float2 toPix  = position - center;
+        float  dist   = length(toPix);
+
+        if (!isfinite(dist)) {
+            continue;
+        }
+
+        float2 dir = (dist > 1e-4) ? (toPix / dist) : float2(0.0, 0.0);
+
+        float phase = (dist / safeWavelength) - (age * speed);
+        float wave  = sin(phase * tau);
+        float waveFront = max(0.0, (age * speed) * safeWavelength);
+        float k = (dist - waveFront) / safeRing;
+        float envelope = exp(-k * k);
+        float globalFalloff = exp(-dist / falloffRadius);
+        float disp = wave * amp * envelope * globalFalloff;
+
+        const float maxDisp = 0.6 * safeWavelength;
+        disp = clamp(disp, -maxDisp, maxDisp);
+
+        totalOffset += dir * disp;
+        maxEnvelope = max(maxEnvelope, envelope);
+        totalMagnitude += fabs(disp);
+    }
+
+    half4 baseSample = layer.sample(position);
+
+    float crestInfluence = clamp(maxEnvelope, 0.0, 1.0);
+    float averageMagnitude = totalMagnitude / (safeWavelength * max(1.0, float(count)));
+    float intensity = clamp(0.6 * crestInfluence + 0.4 * averageMagnitude, 0.0, 1.25);
+
+    float2 refractOffset = totalOffset * safeRefraction;
+    float2 offsetR = position + refractOffset * (1.0 + safeDispersion);
+    float2 offsetG = position + refractOffset;
+    float2 offsetB = position + refractOffset * (1.0 - safeDispersion);
+
+    half prismR = layer.sample(offsetR).r;
+    half prismG = layer.sample(offsetG).g;
+    half prismB = layer.sample(offsetB).b;
+
+    half3 refracted = half3(prismR, prismG, prismB);
+    half3 tinted = mix(refracted, refracted * half3(tintColor), half(safeTint));
+    half mixAmount = half(clamp(intensity, 0.0, 1.0));
+    half3 finalRGB = mix(baseSample.rgb, tinted, mixAmount);
+    finalRGB = clamp(finalRGB, half3(0.0), half3(1.0));
+
+    return half4(finalRGB, baseSample.a);
+}
+
+[[ stitchable ]]
+half4 rippleClusterGlowColor(float2 position,
+                             SwiftUI::Layer layer,
+                             float2 size,
+                             float  wavelength,
+                             float  speed,
+                             float  ringWidth,
+                             float  glowStrength,
+                             float  highlightPower,
+                             float  highlightBoost,
+                             float3 glowColor,
+                             constant float *rippleData,
+                             int    rippleFloatCount)
+{
+    if (!isfinite(wavelength) || !isfinite(speed) || !isfinite(ringWidth) ||
+        !isfinite(glowStrength) || !isfinite(highlightPower) || !isfinite(highlightBoost)) {
+        return layer.sample(position);
+    }
+
+    if (rippleData == nullptr || rippleFloatCount < 4) {
+        return layer.sample(position);
+    }
+
+    const float tau = 6.28318530718;
+    const float safeWavelength = max(wavelength, 1.0);
+    const float safeRing = max(ringWidth, 1.0);
+    const float falloffRadius = 0.5 * length(size);
+
+    int limitedFloatCount = clamp(rippleFloatCount, 0, 64 * 4);
+    int count = limitedFloatCount / 4;
+    if (count <= 0) {
+        return layer.sample(position);
+    }
+
+    float maxEnvelope = 0.0;
+    float energyAccum = 0.0;
+
+    for (int i = 0; i < count; ++i) {
+        int baseIndex = i * 4;
+        if ((baseIndex + 3) >= limitedFloatCount) {
+            break;
+        }
+
+        float cx  = rippleData[baseIndex + 0];
+        float cy  = rippleData[baseIndex + 1];
+        float age = rippleData[baseIndex + 2];
+        float amp = rippleData[baseIndex + 3];
+
+        if (!isfinite(cx) || !isfinite(cy) || !isfinite(age) || !isfinite(amp) || amp <= 0.0001) {
+            continue;
+        }
+
+        float2 center = float2(cx, cy);
+        float2 toPix  = position - center;
+        float  dist   = length(toPix);
+
+        if (!isfinite(dist)) {
+            continue;
+        }
+
+        float phase = (dist / safeWavelength) - (age * speed);
+        float wave  = sin(phase * tau);
+        float waveFront = max(0.0, (age * speed) * safeWavelength);
+        float k = (dist - waveFront) / safeRing;
+        float envelope = exp(-k * k);
+        float globalFalloff = exp(-dist / falloffRadius);
+        float disp = fabs(wave * amp * envelope * globalFalloff);
+
+        const float maxDisp = 0.6 * safeWavelength;
+        disp = clamp(disp, 0.0, maxDisp);
+
+        maxEnvelope = max(maxEnvelope, envelope);
+        energyAccum += disp;
+    }
+
+    half4 baseSample = layer.sample(position);
+
+    float energy = clamp(energyAccum / (safeWavelength * max(1.0, float(count))), 0.0, 1.5);
+    float crest = clamp(maxEnvelope, 0.0, 1.0);
+    float glow = clamp(glowStrength, 0.0, 3.0) * energy;
+    float highlight = pow(crest, max(0.5, highlightPower));
+    float halo = highlight * clamp(highlightBoost, 0.0, 3.0);
+
+    half3 tint = half3(glowColor);
+    half3 additive = tint * half(glow + halo);
+    half3 result = clamp(baseSample.rgb + additive, half3(0.0), half3(1.0));
+
+    return half4(result, baseSample.a);
+}


### PR DESCRIPTION
## Summary
- add a ripple style catalog with a bottom picker and studio sheet to adjust parameters
- implement prismatic and luminous colour overlays powered by new Metal shaders while preserving the classic multi-ripple path
- extend the ripple field modifiers to support optional styling and expose colour conversion helpers

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e546cedb4483289bb9c281b0df00b0